### PR TITLE
Fix accidental duplicate properties when the verb contains a space

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -177,7 +177,7 @@ const relationshipsToInterfaceProps = (
 			inverseSynonyms,
 			mode,
 			table,
-			key.replace(/ /g, '_'),
+			key,
 		);
 	});
 };


### PR DESCRIPTION
Change-type: patch