### PR TITLE
Avoid misclassifying non-resource arrays in `Expanded`/`Deferred` typings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import type { Types } from '@balena/sbvr-types';
 export type { Types } from '@balena/sbvr-types';
 
-export type Expanded<T> = Extract<T, any[]>;
+export type Expanded<T> = Extract<T, Array<Resource['Read']>>;
 export type PickExpanded<T, K extends keyof T = keyof T> = {
 	[P in K]-?: Expanded<T[P]>;
 };
-export type Deferred<T> = Exclude<T, any[]>;
+export type Deferred<T> = Exclude<T, Array<Resource['Read']>>;
 export type PickDeferred<T, K extends keyof T = keyof T> = {
 	[P in K]: Deferred<T[P]>;
 };


### PR DESCRIPTION
Change-type: patch