### PR TITLE
Fix accidentally omitting `Read` types for computed fields

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -74,7 +74,7 @@ const fieldToInterfaceProps = (
 	f: AbstractSqlField,
 	mode: Mode,
 ): string | undefined => {
-	if (f.computed != null) {
+	if (mode === 'Write' && f.computed != null) {
 		// Computed terms cannot be written to
 		return;
 	}


### PR DESCRIPTION
Change-type: patch