### PR TITLE
Allow sbvr-types v10 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "common-tags": "^1.8.2"
   },
   "peerDependencies": {
-    "@balena/sbvr-types": "^7.1.0 || ^8.0.0 || ^9.0.0"
+    "@balena/sbvr-types": "^7.1.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
   },
   "devDependencies": {
     "@balena/lint": "^9.0.1",


### PR DESCRIPTION
See: https://balena.fibery.io/Work/Project/Make-release-assets-publicly-available-and-maintained-1177
Change-type: patch