### PR TITLE
Allow for sbvr-types v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "common-tags": "^1.8.2"
   },
   "peerDependencies": {
-    "@balena/sbvr-types": "^7.1.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+    "@balena/sbvr-types": "^7.1.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   },
   "devDependencies": {
     "@balena/lint": "^9.0.1",


### PR DESCRIPTION
Change-type: patch

---

See: https://balena.fibery.io/Work/Task/PineJS-Migrate-to-TIMESTAMPTZ-columns-2447